### PR TITLE
Get the gateway working on Qualcomm (SM6150 / Poco X3), Android 16

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.callagent.gateway"
         minSdk = 26
         targetSdk = 34
-        versionCode = 329
-        versionName = "2.8.51"
+        versionCode = 330
+        versionName = "2.8.52"
     }
 
     buildTypes {

--- a/app/src/main/java/com/callagent/gateway/DeviceProfile.kt
+++ b/app/src/main/java/com/callagent/gateway/DeviceProfile.kt
@@ -32,8 +32,11 @@ data class DeviceProfile(
      *  after AudioTrack.play() when route is settled). */
     val mixerIncallMusicCmd: String,
 
-    /** Grep pattern for diagnostic tinymix dump. */
-    val mixerDiagGrep: String,
+    /** Readback of the handful of controls this SoC's bridge depends on.
+     *  Logged before and after [mixerSetupCmd] so a failed setup is visible in
+     *  the call log.  The interesting controls are entirely SoC-specific, so
+     *  each profile owns its own command; empty = skip the readback. */
+    val mixerVerifyCmd: String,
 
     // ── Volume calibration ──
 
@@ -84,6 +87,73 @@ data class DeviceProfile(
     val playbackUsage: Int = -1,
 
     // ── Timing ──
+
+    /** Whether our own playback is audible to the capture source.
+     *
+     *  The double-talk/echo gate exists because on most devices the injected
+     *  agent audio leaks back into capture.  Once playback is routed straight
+     *  to Telephony Tx it never reaches the speaker, so the microphone cannot
+     *  hear it — and the gate then does nothing but discard the caller's voice
+     *  every time the agent talks. */
+    val playbackLeaksIntoCapture: Boolean = true,
+
+    /** Prefer UNPROCESSED/CAMCORDER over the voice-tuned capture sources.
+     *
+     *  When the caller is heard acoustically, the voice sources are the wrong
+     *  tool: their echo canceller and noise suppression are built to remove
+     *  exactly the loudspeaker signal we are trying to record, and their AGC
+     *  pumps the room.  UNPROCESSED bypasses that chain. */
+    val preferUnprocessedMic: Boolean = false,
+
+    /** Ask AudioRecord to capture from the telephony RX device.
+     *
+     *  The mirror of [playbackToTelephonyTx].  Without it, capture on a device
+     *  whose HAL refuses AudioSource.VOICE_CALL falls back to the microphone,
+     *  which records the room rather than the call — the far end is only heard
+     *  at all if the downlink happens to be audible on the speaker, and once
+     *  the downlink is muted there the agent hears nothing but background. */
+    val captureFromTelephonyRx: Boolean = false,
+
+    /** Ask for the playback track to be routed to the telephony TX device.
+     *
+     *  Setting incall_music_enabled is not by itself enough to make
+     *  AudioPolicyManager choose the incall_music_uplink output: the track is
+     *  still attached to the speaker backend.  Naming the telephony device as
+     *  the track's preferred device asks the policy manager for that route
+     *  explicitly, which is something only a privileged app can get away with. */
+    val playbackToTelephonyTx: Boolean = false,
+
+    /** Turn incall_music on before the AudioTrack is created, not after.
+     *
+     *  This HAL decides the output usecase when the track is *created*:
+     *  AudioPolicyManager only offers the incall_music_uplink mixPort — the one
+     *  routed to Telephony Tx — while incall_music_enabled is already true, so
+     *  setting the parameter after play() leaves the track bound to the speaker
+     *  for its whole life.  MSM8930 wants the opposite order (its HAL starts
+     *  the incall-music usecase only once a STREAM_MUSIC output exists), which
+     *  is why this is per-profile rather than simply reordered. */
+    val incallMusicBeforeTrack: Boolean = false,
+
+    /** Open the playback track as stereo rather than mono.
+     *
+     *  Purely a routing key, not a quality choice: the HAL's
+     *  "incall_music_uplink" mixPort — the one the audio policy routes to
+     *  "Telephony Tx" — declares AUDIO_CHANNEL_OUT_STEREO and nothing else, so
+     *  AudioPolicyManager cannot match a mono track to it and quietly hands the
+     *  track to the speaker path instead.  Mono samples are duplicated into
+     *  both channels on the way out. */
+    val playbackStereo: Boolean = false,
+
+    /** Playback buffer size in milliseconds, or 0 for AudioTrack's minimum.
+     *
+     *  This decides which HAL output the track lands on, and therefore whether
+     *  incall_music can reach the modem uplink at all.  A minimum-sized buffer
+     *  qualifies for AudioFlinger's fast path, which the Qualcomm HAL serves
+     *  with low-latency-playback on MultiMedia5; a larger request falls back to
+     *  deep-buffer-playback on MultiMedia1.  On SM6150 the fast path left the
+     *  agent audible on the phone's own speaker while the caller heard nothing
+     *  from it. */
+    val playbackBufferMs: Int = 0,
 
     /** Delay (ms) after speaker route change before mixer setup. */
     val routeChangeDelayMs: Long,
@@ -147,39 +217,25 @@ data class DeviceProfile(
         }
 
         /**
-         * Dump available ALSA mixer controls for diagnostics.
-         * Called once on first audio bridge setup.  Returns the dump for logging.
+         * Dump mixer state for diagnostics, once on the first audio bridge
+         * setup.  The device-specific half comes from the profile's
+         * [mixerVerifyCmd]; everything here is SoC-agnostic.
          */
-        fun discoverMixerControls(): String {
+        fun discoverMixerControls(profile: DeviceProfile): String {
             return try {
-                val sb = StringBuilder()
                 val bin = tinymixBin
-                if (bin.isNotEmpty()) {
-                    // Compact discovery: NSRC/bridge state + ALSA cards only.
-                    // Full routing map established in v2.8.42 — no need for
-                    // bulk control dumps, enum lists, or mixer_paths.xml parsing.
-                    val result = RootShell.execForOutput(
-                        "echo '=== ALSA cards ==='; cat /proc/asound/cards 2>/dev/null; " +
-                        "echo '=== NSRC/Bridge state ==='; " +
-                        "for i in 0 1 2 3 4; do " +
-                        "  echo -n \"NSRC\${i}=\"; $bin \"ABOX NSRC\${i}\" 2>/dev/null || echo 'N/A'; " +
-                        "  echo -n \"NSRC\${i}_Bridge=\"; $bin \"ABOX NSRC\${i} Bridge\" 2>/dev/null || echo 'N/A'; " +
-                        "done; " +
-                        "echo -n 'SoundType='; $bin 'ABOX Sound Type' 2>/dev/null || echo 'N/A'; " +
-                        "echo '=== total controls ==='; $bin 2>&1 | wc -l",
-                        timeoutMs = 8000
+                if (bin.isEmpty()) {
+                    return "=== tinymix not available ===\n" + RootShell.execForOutput(
+                        "cat /proc/asound/cards 2>/dev/null", timeoutMs = 3000
                     )
-                    sb.appendLine(result)
-                } else {
-                    sb.appendLine("=== tinymix not available ===")
-                    val info = RootShell.execForOutput(
-                        "cat /proc/asound/card0/id 2>/dev/null; " +
-                        "cat /proc/asound/card1/id 2>/dev/null",
-                        timeoutMs = 3000
-                    )
-                    sb.appendLine(info)
                 }
-                sb.toString()
+                val verify = resolveCmd(profile.mixerVerifyCmd)
+                RootShell.execForOutput(
+                    "echo '=== ALSA cards ==='; cat /proc/asound/cards 2>/dev/null; " +
+                        (if (verify.isNotEmpty()) "echo '=== ${profile.name} ==='; $verify; " else "") +
+                        "echo '=== total controls ==='; $bin 2>&1 | wc -l",
+                    timeoutMs = 8000
+                )
             } catch (e: Exception) {
                 "Mixer discovery failed: ${e.message}"
             }
@@ -211,6 +267,12 @@ data class DeviceProfile(
                 // Samsung Galaxy S10e Exynos (Exynos 9820)
                 board.contains("exynos9820") || hw.contains("exynos") && model.contains("sm-g970") ->
                     exynos9820()
+
+                // Snapdragon 7-series (SM6150/SM7150) with WCD9375 codec —
+                // e.g. Poco X3 NFC.  Same incall_music path as MSM8930 but a
+                // different codec, so the WCD9304 control names do not apply.
+                board.contains("sm6150") || board.contains("sm7150") ->
+                    sm6150()
 
                 // Generic Qualcomm — try incall_music, skip WCD9304-specific controls
                 hw.contains("qcom") || hw.contains("qualcomm") ->
@@ -311,7 +373,12 @@ data class DeviceProfile(
                 append("tinymix 'Incall_Music Audio Mixer MultiMedia1' 1 2>/dev/null; ")
                 append("tinymix 'Incall_Music Audio Mixer MultiMedia2' 1 2>/dev/null")
             },
-            mixerDiagGrep = "tinymix 2>&1 | grep -iE '(Voice Rx|Voice Tx|Incall_Music|EC_REF|DEC[1-4] Vol|DEC[1-4] MUX|ADC[1-3] Vol|MICBIAS|RX[0-9].*[Vv]ol|SPK DRV|LINEOUT[12] Vol|SLIM TX[0-9])'",
+            mixerVerifyCmd = buildString {
+                append("echo -n 'VoiceRxDevMute='; tinymix 'Voice Rx Device Mute' 2>&1; ")
+                append("echo -n 'VoiceTxMute='; tinymix 'Voice Tx Mute' 2>&1; ")
+                append("echo -n 'IncallMM1='; tinymix 'Incall_Music Audio Mixer MultiMedia1' 2>&1; ")
+                append("echo -n 'IncallMM2='; tinymix 'Incall_Music Audio Mixer MultiMedia2' 2>&1")
+            },
             musicVolPercent = 14,
             captureGain = 2,
             playbackGain = 2,
@@ -404,10 +471,17 @@ data class DeviceProfile(
                 append("echo -n 'NSRC0_Bridge='; tinymix 'ABOX NSRC0 Bridge' 2>/dev/null; ")
                 append("echo -n 'NSRC1_Bridge='; tinymix 'ABOX NSRC1 Bridge' 2>/dev/null")
             },
-            // Diagnostic: NSRC/bridge state only (routing map fully understood).
-            mixerDiagGrep = buildString {
-                append("echo '=== NSRC/Bridge ==='; ")
-                append("tinymix 2>&1 | grep -iE '(nsrc|bridge)' | head -20")
+            // NSRC/bridge state — the controls the TX injection depends on.
+            // These names exist only on Samsung's ABOX DSP; on any other SoC
+            // tinymix answers "control not found", which is why this readback
+            // belongs to the profile rather than the shared call path.
+            mixerVerifyCmd = buildString {
+                append("echo -n 'NSRC0='; tinymix 'ABOX NSRC0' 2>&1; ")
+                append("echo -n 'NSRC1='; tinymix 'ABOX NSRC1' 2>&1; ")
+                append("echo -n 'NSRC0B='; tinymix 'ABOX NSRC0 Bridge' 2>&1; ")
+                append("echo -n 'NSRC1B='; tinymix 'ABOX NSRC1 Bridge' 2>&1; ")
+                append("echo -n 'NSRC2B='; tinymix 'ABOX NSRC2 Bridge' 2>&1; ")
+                append("echo -n 'SPUS0='; tinymix 'ABOX SPUS OUT0' 2>&1")
             },
             musicVolPercent = 40,  // v2.8.45@30%+2x=audible but quiet. Raise for clarity.
             captureGain = 10,      // VOICE_RECOGNITION captures very quietly (rawCapRMS~2)
@@ -435,6 +509,178 @@ data class DeviceProfile(
             appopsPropagationMs = 300,
         )
 
+        /** Qualcomm SM6150/SM7150 (Snapdragon 730/732G) with WCD9375 codec.
+         *
+         *  ALSA card: sm6150-wcd9375-snd-card (3436 controls).
+         *
+         *  Present and used here:
+         *    Incall_Music Audio Mixer MultiMedia1/2/5/9  — digital injection
+         *      of STREAM_MUSIC into the modem uplink, the same mechanism the
+         *      S4 Mini uses and the one the Exynos S10e turned out to lack.
+         *    MultiMedia{1,4,8,9} Mixer VOC_REC_DL/UL     — in-call capture.
+         *      The HAL is supposed to set these when an app opens
+         *      AudioSource.VOICE_CALL; enabling them explicitly costs nothing
+         *      and covers the case where it does not.
+         *    Voice Rx Device Mute / Voice Tx Mute / Voice Tx Device Mute
+         *
+         *  Absent (WCD9304-only, so nothing from the MSM8930 profile that
+         *  touches them applies): MICBIAS* CAPLESS Switch, RX3 Digital Volume,
+         *  SPK DRV Volume, LINEOUT* Volume, Voice Rx Mute, Voip Rx Device Mute.
+         *
+         *  Note the Voice* controls are write-only on this firmware — reading
+         *  them returns "operation not permitted", which is expected and not a
+         *  failure.
+         *
+         *  Levels: capture on this device comes in very quiet (rawCapRMS in the
+         *  20-30 range), so the generic profile's 350 noise gate discarded
+         *  every frame and the far end heard pure silence.
+         */
+        fun sm6150() = DeviceProfile(
+            name = "SM6150/SM7150 (WCD9375)",
+            mixerSetupCmd = buildString {
+                // The downlink has to stay audible on the speaker: capture on
+                // this device is acoustic (the HAL gives no in-call recording
+                // and no telephony-RX capture), so the microphone hearing the
+                // speaker is the only way the agent hears the caller at all.
+                // Muting it is why the agent ended up hearing just the room.
+                append("tinymix 'Voice Rx Device Mute' 0 4294967295 20 2>/dev/null; ")
+                // Keep the uplink stream itself open — incall_music injects
+                // into it — but mute the *device* (microphone) leg of it.
+                // Without this the physical mic is mixed into the modem
+                // uplink, so the caller hears the room and their own voice
+                // coming back off the phone's speaker.  The two controls are
+                // separate on purpose: 'Voice Tx Mute' would silence the whole
+                // TX path including the injected agent audio, whereas
+                // 'Voice Tx Device Mute' drops only the mic contribution.
+                // AudioRecord keeps working — it reads the mic directly rather
+                // than through the voice TX path.
+                // These voice controls are 3-element arrays — the QCOM HAL
+                // writes them as {mute, session_vsid, ramp_ms} with
+                // ALL_SESSION_VSID = 0xFFFFFFFF.  "tinymix 'X' 1" only sets
+                // element 0, leaving mute untouched, which is why the earlier
+                // single-value writes silently did nothing.
+                append("tinymix 'Voice Tx Mute' 0 4294967295 20 2>/dev/null; ")
+                append("tinymix 'Voice Tx Device Mute' 1 4294967295 20 2>/dev/null; ")
+                // Digital injection: agent audio -> modem uplink.
+                // MultiMedia5 is the one that matters here: with a voice call
+                // up, the AudioTrack lands on MultiMedia5 (visible as
+                // "TERT_MI2S_RX Audio Mixer MultiMedia5: On"), not MultiMedia1/2
+                // the way it does on MSM8930.  Opening only MM1/MM2 left the
+                // agent's audio going to the speaker instead of the uplink, so
+                // the caller heard nothing from the agent — only their own
+                // voice echoing back off the mic.  All four available ports are
+                // opened so this survives the HAL choosing another front-end.
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia1' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia2' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia5' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia9' 1 2>/dev/null; ")
+                // In-call record direction.  The driver accepts 0-2 only
+                // (3/"both" is rejected as invalid argument), and it sits at 1
+                // — uplink — by default.  Uplink is our own side of the call,
+                // i.e. the audio incall_music injects, so capturing it fed the
+                // agent its own echo and read rawCapRMS≈5.  Downlink is the
+                // caller's voice, which is what the agent needs to hear.
+                append("tinymix 'Voc Rec Config' 2 2>/dev/null; ")
+                // In-call capture: both legs of the voice call into the
+                // MultiMedia capture ports AudioRecord may land on.
+                append("tinymix 'MultiMedia1 Mixer VOC_REC_DL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia1 Mixer VOC_REC_UL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia4 Mixer VOC_REC_DL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia4 Mixer VOC_REC_UL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia8 Mixer VOC_REC_DL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia8 Mixer VOC_REC_UL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia9 Mixer VOC_REC_DL' 1 2>/dev/null; ")
+                append("tinymix 'MultiMedia9 Mixer VOC_REC_UL' 1 2>/dev/null")
+            },
+            mixerRestoreCmd = buildString {
+                append("tinymix 'Voice Rx Device Mute' 0 4294967295 20 2>/dev/null; ")
+                append("tinymix 'Voice Tx Device Mute' 0 4294967295 20 2>/dev/null; ")
+                append("tinymix 'Voice Tx Mute' 0 4294967295 20 2>/dev/null; ")
+                append("tinymix 'Voc Rec Config' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia1' 0 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia2' 0 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia5' 0 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia9' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia1 Mixer VOC_REC_DL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia1 Mixer VOC_REC_UL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia4 Mixer VOC_REC_DL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia4 Mixer VOC_REC_UL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia8 Mixer VOC_REC_DL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia8 Mixer VOC_REC_UL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia9 Mixer VOC_REC_DL' 0 2>/dev/null; ")
+                append("tinymix 'MultiMedia9 Mixer VOC_REC_UL' 0 2>/dev/null")
+            },
+            mixerIncallMusicCmd = buildString {
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia1' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia2' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia5' 1 2>/dev/null; ")
+                append("tinymix 'Incall_Music Audio Mixer MultiMedia9' 1 2>/dev/null; ")
+                append("tinymix 'Voice Tx Mute' 0 4294967295 20 2>/dev/null; ")
+                // Re-assert the mic mute here as well as in mixerSetupCmd.  The
+                // write is accepted either way (rc=0), but the HAL rewrites the
+                // voice mutes while it brings the call up, so the one issued
+                // during mixer setup is overwritten before the call is
+                // established and the caller keeps hearing the room.  This
+                // command runs once playback is going, i.e. after the HAL has
+                // settled.
+                append("tinymix 'Voice Tx Device Mute' 1 4294967295 20 2>/dev/null")
+            },
+            mixerVerifyCmd = buildString {
+                append("echo -n 'IncallMM1='; tinymix 'Incall_Music Audio Mixer MultiMedia1' 2>&1; ")
+                append("echo -n 'IncallMM2='; tinymix 'Incall_Music Audio Mixer MultiMedia2' 2>&1; ")
+                append("echo -n 'IncallMM5='; tinymix 'Incall_Music Audio Mixer MultiMedia5' 2>&1; ")
+                append("echo -n 'VocRecDL='; tinymix 'MultiMedia1 Mixer VOC_REC_DL' 2>&1; ")
+                append("echo -n 'VocRecUL='; tinymix 'MultiMedia1 Mixer VOC_REC_UL' 2>&1; ")
+                append("echo -n 'VocRecCfg='; tinymix 'Voc Rec Config' 2>&1")
+            },
+            musicVolPercent = 20,
+            // Capture is acoustic here (the mic), so gain multiplies room
+            // noise as well as speech, and the agent's VAD sees that noise.
+            captureGain = 4,
+            playbackGain = 2,
+            // 40-55 was measured against a loud recorded announcement; a real
+            // caller coming through the speaker only reaches rawCapRMS 19-26,
+            // and a gate of 30 discarded nearly all of it (noise=561 vs
+            // fwd=481, capRMS=0) so the agent heard nothing at all.  Sits just
+            // under the speech floor instead; voiceCallVolPercent below is what
+            // buys back the headroom over room noise.
+            noiseGateThreshold = 12,
+            echoGateThreshold = 300,
+            doubleTalkRatio = 1.5f,
+            requireSpeakerMode = true,
+            incallMusicParam = "incall_music_enabled",
+            // Capture is acoustic, so the caller's voice has to be loud on the
+            // speaker for the microphone to pick it out of the room.  Nothing
+            // of ours plays locally any more — the agent's audio goes straight
+            // to Telephony Tx — so there is no feedback cost to turning this up.
+            voiceCallVolPercent = 100,
+            // Measured silent on this build (rawCapRMS 0-1) even with
+            // VOC_REC_DL routed and Voc Rec Config on downlink.  Leaving it
+            // ahead of the mic only burned 2-3s of every call failing over.
+            voiceDownlinkWorks = false,
+            // Playback goes to Telephony Tx, never to the speaker, so the mic
+            // cannot hear it and the echo gate has nothing to gate.
+            playbackLeaksIntoCapture = false,
+            preferUnprocessedMic = true,
+            // Measured: TYPE_TELEPHONY is offered as an input and
+            // setPreferredDevice is accepted (routedFrom=18), but every source
+            // then reads rawCapRMS=0 — this HAL provides no downlink capture,
+            // and forcing the route takes the working mic fallback with it.
+            captureFromTelephonyRx = false,
+            playbackToTelephonyTx = true,
+            // The HAL binds the usecase at track creation, so the parameter
+            // has to be set first.
+            incallMusicBeforeTrack = true,
+            // The incall_music_uplink mixPort accepts stereo only.
+            playbackStereo = true,
+            // Force deep-buffer playback (MultiMedia1) instead of the fast
+            // path (MultiMedia5), so the Incall_Music mixer actually has the
+            // track to inject.
+            playbackBufferMs = 100,
+            routeChangeDelayMs = 500,
+            appopsPropagationMs = 300,
+        )
+
         /** Generic Qualcomm device — tries incall_music, generic controls */
         fun genericQualcomm() = DeviceProfile(
             name = "Generic Qualcomm",
@@ -452,7 +698,12 @@ data class DeviceProfile(
                 append("tinymix 'Incall_Music Audio Mixer MultiMedia2' 1 2>/dev/null; ")
                 append("tinymix 'Voice Tx Mute' 0 2>/dev/null")
             },
-            mixerDiagGrep = "tinymix 2>&1 | grep -iE '(voice|incall|music|multimedia)'",
+            mixerVerifyCmd = buildString {
+                append("echo -n 'VoiceRxDevMute='; tinymix 'Voice Rx Device Mute' 2>&1; ")
+                append("echo -n 'VoiceTxMute='; tinymix 'Voice Tx Mute' 2>&1; ")
+                append("echo -n 'IncallMM1='; tinymix 'Incall_Music Audio Mixer MultiMedia1' 2>&1; ")
+                append("echo -n 'IncallMM2='; tinymix 'Incall_Music Audio Mixer MultiMedia2' 2>&1")
+            },
             musicVolPercent = 20,
             captureGain = 1,
             playbackGain = 2,
@@ -479,7 +730,10 @@ data class DeviceProfile(
                 append("tinymix 'Sub Mic Switch' 1 2>/dev/null")
             },
             mixerIncallMusicCmd = "",  // May not have incall_music
-            mixerDiagGrep = "tinymix 2>&1 | grep -iE '(mic|spk|voice|abox)'",
+            mixerVerifyCmd = buildString {
+                append("echo -n 'MainMic='; tinymix 'Main Mic Switch' 2>&1; ")
+                append("echo -n 'SubMic='; tinymix 'Sub Mic Switch' 2>&1")
+            },
             musicVolPercent = 20,
             captureGain = 1,
             playbackGain = 2,
@@ -499,7 +753,7 @@ data class DeviceProfile(
             mixerSetupCmd = "",
             mixerRestoreCmd = "",
             mixerIncallMusicCmd = "",
-            mixerDiagGrep = "tinymix 2>&1 | head -30",
+            mixerVerifyCmd = "",
             musicVolPercent = 20,
             captureGain = 1,
             playbackGain = 2,

--- a/app/src/main/java/com/callagent/gateway/MainActivity.kt
+++ b/app/src/main/java/com/callagent/gateway/MainActivity.kt
@@ -448,12 +448,14 @@ class MainActivity : AppCompatActivity() {
         val etPort = view.findViewById<EditText>(R.id.etSipPort)
         val etUser = view.findViewById<EditText>(R.id.etSipUser)
         val etPassword = view.findViewById<EditText>(R.id.etSipPassword)
+        val etOwnNumber = view.findViewById<EditText>(R.id.etOwnNumber)
         val cbAutoconnect = view.findViewById<CheckBox>(R.id.cbAutoconnect)
 
-        etServer.setText(prefs.getString("server", "sip.callagent.pro"))
+        etServer.setText(prefs.getString("server", "callagent.pro"))
         etPort.setText(prefs.getInt("port", 5060).toString())
         etUser.setText(prefs.getString("user", ""))
         etPassword.setText(prefs.getString("pass", ""))
+        etOwnNumber.setText(prefs.getString("own_number", "+49123123123123"))
         cbAutoconnect.isChecked = prefs.getBoolean("autoconnect", true)
 
         AlertDialog.Builder(this)
@@ -464,14 +466,19 @@ class MainActivity : AppCompatActivity() {
                 val port = etPort.text.toString().trim().toIntOrNull() ?: 5060
                 val user = etUser.text.toString().trim()
                 val pass = etPassword.text.toString().trim()
+                val ownNumber = etOwnNumber.text.toString().trim()
                 prefs.edit()
                     .putString("server", server)
                     .putInt("port", port)
                     .putString("user", user)
                     .putString("pass", pass)
+                    .putString("own_number", ownNumber)
                     .putBoolean("autoconnect", cbAutoconnect.isChecked)
                     .apply()
-                appendLog("Config saved: $user@$server:$port (autoconnect=${cbAutoconnect.isChecked})")
+                appendLog(
+                    "Config saved: $user@$server:$port " +
+                        "(own=${ownNumber.ifEmpty { "auto" }}, autoconnect=${cbAutoconnect.isChecked})"
+                )
             }
             .setNegativeButton("Cancel", null)
             .show()
@@ -1168,6 +1175,17 @@ class MainActivity : AppCompatActivity() {
         val number = tvDialNumber.text.toString().trim()
         if (number.isEmpty()) {
             Toast.makeText(this, "Enter a number to call", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (com.callagent.gateway.gsm.GsmCallManager.isMmiCode(number)) {
+            appendLog("Sending MMI $number")
+            com.callagent.gateway.gsm.GsmCallManager.sendMmi(this, number) { result ->
+                runOnUiThread {
+                    appendLog("MMI result: $result")
+                    Toast.makeText(this, result, Toast.LENGTH_LONG).show()
+                }
+            }
             return
         }
 

--- a/app/src/main/java/com/callagent/gateway/bridge/CallOrchestrator.kt
+++ b/app/src/main/java/com/callagent/gateway/bridge/CallOrchestrator.kt
@@ -1,8 +1,12 @@
 package com.callagent.gateway.bridge
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import android.telecom.Call
+import android.telephony.PhoneNumberUtils
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
 import android.util.Log
 import com.callagent.gateway.RootShell
 import com.callagent.gateway.gsm.GsmCallManager
@@ -93,8 +97,93 @@ class CallOrchestrator(
         GsmCallManager.listener = null
     }
 
+    /**
+     * The number this gateway answers on, sent as the SIP destination.
+     *
+     * The server maps an incoming number to an assistant the same way it does
+     * a Fritz!Box DID, so it needs the MSISDN of our SIM here.  Addressing our
+     * own SIP account instead makes the platform see account N calling account
+     * N, match it as a local peer and ring us straight back — the INVITE comes
+     * back, the orchestrator rejects it as busy, and the GSM leg is never
+     * answered.
+     *
+     * Asks the platform first; many carriers do not publish the number on the
+     * SIM, in which case the configured value is used.
+     */
+    private fun inboundSipDestination(): String {
+        simNumber()?.let {
+            val intl = toInternational(it)
+            Log.i(TAG, "Own number from SIM: $it → $intl")
+            return intl
+        }
+        val configured = context.getSharedPreferences("gateway", Context.MODE_PRIVATE)
+            .getString("own_number", DEFAULT_OWN_NUMBER)?.trim().orEmpty()
+        if (configured.isNotEmpty()) {
+            val intl = toInternational(configured)
+            Log.i(TAG, "Own number from settings: $configured → $intl")
+            return intl
+        }
+        Log.w(TAG, "No own number known — addressing our own extension, which loops back")
+        return sipClient.username
+    }
+
+    /**
+     * The destination always goes out in international form.  What we have to
+     * start from varies: the platform may hand back E.164, the settings field
+     * may hold a national number ("015215320372"), and either may use a 00
+     * prefix.  PhoneNumberUtils resolves the national case against the SIM's
+     * country rather than us guessing a dialling code.
+     *
+     * The caller number in From is deliberately NOT put through this — that one
+     * is passed on exactly as the carrier delivered it.
+     */
+    private fun toInternational(number: String): String {
+        val trimmed = number.trim().filterNot { it == ' ' || it == '-' || it == '/' }
+        if (trimmed.startsWith("+")) return trimmed
+        if (trimmed.startsWith("00")) return "+" + trimmed.substring(2)
+        val iso = try {
+            (context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+                .simCountryIso?.uppercase()?.ifEmpty { null }
+        } catch (e: Exception) {
+            Log.w(TAG, "SIM country unavailable: ${e.message}")
+            null
+        }
+        if (iso != null) {
+            PhoneNumberUtils.formatNumberToE164(trimmed, iso)?.let { return it }
+        }
+        Log.w(TAG, "Cannot make '$trimmed' international (SIM country=$iso) — sending as is")
+        return trimmed
+    }
+
+    /** The SIM's own number, when the carrier publishes it — many do not. */
+    @SuppressLint("MissingPermission")
+    private fun simNumber(): String? = try {
+        val number = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.getSystemService(SubscriptionManager::class.java)
+                ?.getPhoneNumber(SubscriptionManager.getDefaultSubscriptionId())
+        } else {
+            @Suppress("DEPRECATION")
+            (context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager).line1Number
+        }
+        number?.trim()?.ifEmpty { null }
+    } catch (e: Exception) {
+        Log.w(TAG, "SIM number unavailable: ${e.message}")
+        null
+    }
+
     /** Initiate an outgoing GSM call from the dialler, then bridge to SIP */
     fun initiateDiallerCall(number: String) {
+        // MMI/USSD is not a call — it never produces a Telecom Connection, so
+        // arming the bridge for it would strand us in GSM_DIALING until the
+        // stale-state timeout.
+        if (GsmCallManager.isMmiCode(number)) {
+            Log.i(TAG, "MMI code $number — sending as USSD, not bridging")
+            GsmCallManager.sendMmi(context, number) { result ->
+                Log.i(TAG, "MMI result: $result")
+                listener?.onStateChanged(bridgeState, "MMI: $result")
+            }
+            return
+        }
         if (bridgeState != BridgeState.IDLE) {
             // Check for stale state: if bridge has been non-IDLE for too long
             // without reaching BRIDGED, force a reset.  This happens on cold boot
@@ -395,7 +484,7 @@ class CallOrchestrator(
 
         val rtpPort = allocateRtpPort()
         val sipCall = sipClient.makeCall(
-            targetExtension = sipClient.username, // call our own extension — Asterisk routes to agent
+            targetExtension = inboundSipDestination(),
             localRtpPort = rtpPort,
             callerIdNumber = callerNumber,
             callerIdName = callerNumber
@@ -618,5 +707,8 @@ class CallOrchestrator(
         private const val GSM_DIAL_TIMEOUT_MS = 45_000L
         /** If bridge is non-IDLE for this long, consider it stale */
         private const val STALE_STATE_TIMEOUT_MS = 60_000L
+
+        /** Placeholder shown in settings until a real MSISDN is entered. */
+        private const val DEFAULT_OWN_NUMBER = "+49123123123123"
     }
 }

--- a/app/src/main/java/com/callagent/gateway/gsm/GsmCallManager.kt
+++ b/app/src/main/java/com/callagent/gateway/gsm/GsmCallManager.kt
@@ -1,12 +1,18 @@
 package com.callagent.gateway.gsm
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.telecom.Call
 import android.telecom.CallAudioState
 import android.telecom.InCallService
+import android.telecom.TelecomManager
+import android.telephony.TelephonyManager
 import android.util.Log
 import com.callagent.gateway.DeviceProfile
 import com.callagent.gateway.RootShell
@@ -159,11 +165,99 @@ object GsmCallManager {
     }
 
     /** Place outgoing GSM call via the SIM */
+    /**
+     * Place an outgoing GSM call.
+     *
+     * Uses TelecomManager.placeCall rather than startActivity(ACTION_CALL).
+     * The gateway dials from a foreground service with no visible Activity,
+     * and Android 15+ blocks background activity launches, so the intent form
+     * never reaches Telecom at all — it is dropped with BAL_BLOCK and the call
+     * simply never happens.  placeCall is a binder call into Telecom, needs no
+     * Activity, and we hold CALL_PHONE (plus CALL_PRIVILEGED as a priv-app);
+     * as the default dialer, Telecom hands the call back to our InCallService.
+     *
+     * The ACTION_CALL path is kept as a fallback for the case where Telecom
+     * refuses the direct call — it still works whenever an Activity is up.
+     */
+    /**
+     * True for dial strings that are MMI/USSD codes rather than phone numbers
+     * — anything containing '*' or '#', e.g. *132# (balance) or *#06# (IMEI).
+     *
+     * These must never reach placeCall: Telecom rejects them with
+     * "Connection is null, DIALED_MMI", and on this build that took
+     * TelephonyConnectionService down with it.
+     */
+    fun isMmiCode(dialString: String): Boolean {
+        val s = dialString.trim()
+        return s.isNotEmpty() && (s.contains('*') || s.contains('#'))
+    }
+
+    /**
+     * Run an MMI/USSD code and report the network's answer via [onResult].
+     *
+     * USSD codes (those ending in '#') go through sendUssdRequest, which hands
+     * the reply back to us so it can be logged — useful on a headless gateway
+     * where nobody is watching for a system dialog.  Anything else (IMEI
+     * lookups, call-forwarding shortcuts) goes to Telecom's own MMI handling.
+     */
+    @SuppressLint("MissingPermission")
+    fun sendMmi(context: Context, dialString: String, onResult: (String) -> Unit) {
+        val code = dialString.trim()
+        if (code.endsWith("#")) {
+            try {
+                val telephony =
+                    context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+                telephony.sendUssdRequest(
+                    code,
+                    object : TelephonyManager.UssdResponseCallback() {
+                        override fun onReceiveUssdResponse(
+                            tm: TelephonyManager, request: String, response: CharSequence
+                        ) {
+                            Log.i(TAG, "USSD $request → $response")
+                            onResult(response.toString())
+                        }
+
+                        override fun onReceiveUssdResponseFailed(
+                            tm: TelephonyManager, request: String, failureCode: Int
+                        ) {
+                            Log.w(TAG, "USSD $request failed (code $failureCode)")
+                            onResult("USSD $request failed (code $failureCode)")
+                        }
+                    },
+                    Handler(Looper.getMainLooper())
+                )
+                return
+            } catch (e: Exception) {
+                Log.w(TAG, "sendUssdRequest failed (${e.message}) — falling back to Telecom")
+            }
+        }
+        try {
+            val telecom = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+            val handled = telecom.handleMmi(code)
+            onResult(if (handled) "MMI $code sent" else "MMI $code not recognised")
+        } catch (e: Exception) {
+            onResult("MMI $code failed: ${e.message}")
+        }
+    }
+
+    @SuppressLint("MissingPermission")
     fun makeCall(context: Context, destination: String) {
         Log.i(TAG, "Making GSM call to $destination")
-        val intent = Intent(Intent.ACTION_CALL, Uri.parse("tel:$destination"))
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
+        val uri = Uri.fromParts("tel", destination, null)
+        try {
+            val telecom = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+            telecom.placeCall(uri, Bundle())
+            return
+        } catch (e: Exception) {
+            Log.w(TAG, "placeCall failed (${e.message}) — falling back to ACTION_CALL")
+        }
+        try {
+            context.startActivity(
+                Intent(Intent.ACTION_CALL, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "ACTION_CALL fallback failed: ${e.message}")
+        }
     }
 
     /** Music volume percent — from device profile. */
@@ -177,7 +271,7 @@ object GsmCallManager {
         discoveryDone = true
         Thread({
             try {
-                val discovery = DeviceProfile.discoverMixerControls()
+                val discovery = DeviceProfile.discoverMixerControls(profile)
                 for (line in discovery.lines()) {
                     if (line.isNotBlank()) Log.i(TAG, "MixerDiscovery: $line")
                 }
@@ -197,7 +291,7 @@ object GsmCallManager {
     /** Configure audio for GSM↔SIP bridge using the active device profile. */
     private fun configureAudioBridge() {
         try {
-            // Run ABOX/ALSA discovery on first call for diagnostics
+            // Run ALSA mixer discovery on first call for diagnostics
             runMixerDiscovery()
 
             inCallService?.let { service ->
@@ -340,32 +434,22 @@ object GsmCallManager {
             return
         }
         try {
-            val bin = DeviceProfile.tinymixBin
-            // Step 1: Readback BEFORE — see what HAL set during call setup
-            val before = RootShell.execForOutput(buildString {
-                append("echo 'NSRC0B:'; $bin 'ABOX NSRC0 Bridge' 2>&1; ")
-                append("echo 'NSRC1B:'; $bin 'ABOX NSRC1 Bridge' 2>&1; ")
-                append("echo 'NSRC0:'; $bin 'ABOX NSRC0' 2>&1; ")
-                append("echo 'NSRC1:'; $bin 'ABOX NSRC1' 2>&1; ")
-                append("echo 'SPUS0:'; $bin 'ABOX SPUS OUT0' 2>&1")
-            }, timeoutMs = 8000)
-            appLog("Mixer BEFORE: $before")
+            // Readback before/after so a setup that silently did nothing is
+            // visible in the call log.  Which controls matter is SoC-specific,
+            // so the profile supplies the command — the ABOX names this used
+            // to hardcode exist only on Samsung's DSP and answered "control
+            // not found" on every other device.
+            val verify = DeviceProfile.resolveCmd(profile.mixerVerifyCmd)
+            if (verify.isNotEmpty()) {
+                appLog("Mixer BEFORE: ${RootShell.execForOutput(verify, timeoutMs = 8000)}")
+            }
 
-            // Step 2: Run mixer setup commands (all ABOX controls on card 0)
-            // Use execForOutput to capture discovery/diagnostic output from setup commands
             val setupOutput = RootShell.execForOutput(resolvedSetup, timeoutMs = 8000)
             if (setupOutput.isNotBlank()) appLog("Mixer setup: $setupOutput")
 
-            // Step 3: Readback AFTER — verify controls were actually changed
-            val readback = RootShell.execForOutput(buildString {
-                append("echo 'NSRC0B:'; $bin 'ABOX NSRC0 Bridge' 2>&1; ")
-                append("echo 'NSRC1B:'; $bin 'ABOX NSRC1 Bridge' 2>&1; ")
-                append("echo 'NSRC2B:'; $bin 'ABOX NSRC2 Bridge' 2>&1; ")
-                append("echo 'NSRC0:'; $bin 'ABOX NSRC0' 2>&1; ")
-                append("echo 'NSRC1:'; $bin 'ABOX NSRC1' 2>&1; ")
-                append("echo 'SPUS0:'; $bin 'ABOX SPUS OUT0' 2>&1")
-            }, timeoutMs = 10000)
-            appLog("Mixer AFTER: $readback")
+            if (verify.isNotEmpty()) {
+                appLog("Mixer AFTER: ${RootShell.execForOutput(verify, timeoutMs = 10000)}")
+            }
         } catch (e: Exception) {
             appLog("Mixer setup FAILED: ${e.message}")
         }

--- a/app/src/main/java/com/callagent/gateway/rtp/RtpSession.kt
+++ b/app/src/main/java/com/callagent/gateway/rtp/RtpSession.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.os.Build
+import android.media.AudioDeviceInfo
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioRecord
@@ -51,6 +52,8 @@ class RtpSession(
     private var socket: DatagramSocket? = null
     private var audioRecord: AudioRecord? = null
     private var audioTrack: AudioTrack? = null
+    /** 1 or 2, per [DeviceProfile.playbackStereo]. */
+    private var playbackChannels = 1
 
     // Codec
     private val g722Encoder = G722Codec()
@@ -202,6 +205,24 @@ class RtpSession(
         // caller's voice from the speaker.  This is acoustic coupling — not
         // ideal but functional when digital capture sources fail.
         // VOICE_RECOGNITION bypasses noise suppression that can mute call audio.
+        // VOICE_DOWNLINK ahead of the acoustic sources when the profile says
+        // it works here.  It captures the caller's voice digitally, off the
+        // modem downlink, which is what lets the physical mic stay muted — on
+        // the acoustic path the mic is the capture source, so the caller hears
+        // the room and the agent hears itself through the speaker.
+        if (profile.voiceDownlinkWorks) {
+            if (wideband) {
+                configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
+            }
+            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
+        }
+        if (profile.preferUnprocessedMic) {
+            // Raw mic, ahead of the voice-tuned sources: no AEC, no noise
+            // suppression, no AGC.  When the caller reaches us as sound out of
+            // the phone's own speaker, those are all working against us.
+            configs.add(SourceConfig(MediaRecorder.AudioSource.UNPROCESSED, "UNPROCESSED", 8000))
+            configs.add(SourceConfig(MediaRecorder.AudioSource.CAMCORDER, "CAMCORDER", 8000))
+        }
         configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_RECOGNITION, "VOICE_RECOGNITION", 8000))
         configs.add(SourceConfig(MediaRecorder.AudioSource.MIC, "MIC", 8000))
         configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_COMMUNICATION, "VOICE_COMMUNICATION", 8000))
@@ -210,10 +231,10 @@ class RtpSession(
         // Incall_Rec mixer controls don't exist on this SoC.  If it were
         // earlier in the list, it would "win" over mic-based sources that
         // actually work.  Kept only for devices where it genuinely works.
-        if (wideband) {
-            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
-            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
-        } else {
+        if (!profile.voiceDownlinkWorks) {
+            if (wideband) {
+                configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
+            }
             configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
         }
 
@@ -253,6 +274,9 @@ class RtpSession(
                         AudioFormat.ENCODING_PCM_16BIT,
                         bufSize
                     )
+                    if (profile.captureFromTelephonyRx) {
+                        routeCaptureToTelephonyRx(rec)
+                    }
                     if (rec.state == AudioRecord.STATE_INITIALIZED) {
                         record = rec
                         usedSource = cfg.name
@@ -291,10 +315,22 @@ class RtpSession(
         // AudioTrack output digitally into the modem uplink — there is no
         // acoustic speaker→mic path, so deep-buffer headroom is unnecessary.
         // Writing silence when the jitter buffer is empty prevents underruns.
+        val playChannelMask = if (profile.playbackStereo)
+            AudioFormat.CHANNEL_OUT_STEREO else AudioFormat.CHANNEL_OUT_MONO
+        playbackChannels = if (profile.playbackStereo) 2 else 1
         val minPlayBuf = AudioTrack.getMinBufferSize(
-            playbackRate, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT
+            playbackRate, playChannelMask, AudioFormat.ENCODING_PCM_16BIT
         )
-        val playBufSize = minPlayBuf
+        // A minimum-sized buffer qualifies for the fast path, which the
+        // Qualcomm HAL serves on MultiMedia5 — a front-end whose audio goes to
+        // the speaker, not into the voice uplink.  Asking for a larger buffer
+        // pushes the HAL to deep-buffer-playback on MultiMedia1, which is the
+        // front-end the Incall_Music mixer injects from.
+        val playBufSize = if (profile.playbackBufferMs > 0) {
+            maxOf(minPlayBuf, playbackRate * 2 * playbackChannels * profile.playbackBufferMs / 1000)
+        } else {
+            minPlayBuf
+        }
 
         // Profile-controlled playback usage:
         // USAGE_MEDIA (default / MSM8930): Maps to STREAM_MUSIC.  Qualcomm's
@@ -321,6 +357,12 @@ class RtpSession(
             AudioAttributes.USAGE_VOICE_COMMUNICATION -> "VOICE_COMMUNICATION"
             else -> "usage=$usage"
         }
+        // Must happen before the track exists on HALs that pick the output
+        // usecase at creation time — see DeviceProfile.incallMusicBeforeTrack.
+        if (profile.incallMusicBeforeTrack) {
+            enableIncallMusic()
+        }
+
         val track = AudioTrack.Builder()
             .setAudioAttributes(
                 AudioAttributes.Builder()
@@ -331,7 +373,7 @@ class RtpSession(
             .setAudioFormat(
                 AudioFormat.Builder()
                     .setSampleRate(playbackRate)
-                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .setChannelMask(playChannelMask)
                     .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                     .build()
             )
@@ -340,12 +382,18 @@ class RtpSession(
             .build()
         audioTrack = track
 
+        if (profile.playbackToTelephonyTx) {
+            routeToTelephonyTx(track)
+        }
+
         // No platform AEC — AudioTrack is on USAGE_MEDIA (different stream
         // from AudioRecord), so platform AEC can't reference it anyway.
         // For VOICE_DOWNLINK, AEC was over-canceling (capRMS dropped from 252 to ~5).
         // Echo cancellation is handled by Asterisk on the server side.
 
-        Log.i(TAG, "Audio init: playRate=$playbackRate playUsage=$playbackUsageName capture=${if (audioRecord != null) audioSourceName else "deferred"} profile=${profile.name}")
+        Log.i(TAG, "Audio init: playRate=$playbackRate playUsage=$playbackUsageName " +
+            "playBuf=$playBufSize(min=$minPlayBuf) ch=$playbackChannels " +
+            "capture=${if (audioRecord != null) audioSourceName else "deferred"} profile=${profile.name}")
         return true
     }
 
@@ -417,7 +465,10 @@ class RtpSession(
                             AudioFormat.ENCODING_PCM_16BIT,
                             bufSize
                         )
-                        if (rec.state == AudioRecord.STATE_INITIALIZED) {
+                        if (profile.captureFromTelephonyRx) {
+                        routeCaptureToTelephonyRx(rec)
+                    }
+                    if (rec.state == AudioRecord.STATE_INITIALIZED) {
                             if (!running.get()) { rec.release(); return }
                             audioRecord = rec
                             audioSessionId = rec.audioSessionId
@@ -475,13 +526,31 @@ class RtpSession(
         } else {
             configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_CALL, "VOICE_CALL", 8000))
         }
+        // VOICE_DOWNLINK ahead of the acoustic sources when the profile says
+        // it works here.  It captures the caller's voice digitally, off the
+        // modem downlink, which is what lets the physical mic stay muted — on
+        // the acoustic path the mic is the capture source, so the caller hears
+        // the room and the agent hears itself through the speaker.
+        if (profile.voiceDownlinkWorks) {
+            if (wideband) {
+                configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
+            }
+            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
+        }
+        if (profile.preferUnprocessedMic) {
+            // Raw mic, ahead of the voice-tuned sources: no AEC, no noise
+            // suppression, no AGC.  When the caller reaches us as sound out of
+            // the phone's own speaker, those are all working against us.
+            configs.add(SourceConfig(MediaRecorder.AudioSource.UNPROCESSED, "UNPROCESSED", 8000))
+            configs.add(SourceConfig(MediaRecorder.AudioSource.CAMCORDER, "CAMCORDER", 8000))
+        }
         configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_RECOGNITION, "VOICE_RECOGNITION", 8000))
         configs.add(SourceConfig(MediaRecorder.AudioSource.MIC, "MIC", 8000))
         configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_COMMUNICATION, "VOICE_COMMUNICATION", 8000))
-        if (wideband) {
-            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
-            configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
-        } else {
+        if (!profile.voiceDownlinkWorks) {
+            if (wideband) {
+                configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK@16k", 16000))
+            }
             configs.add(SourceConfig(MediaRecorder.AudioSource.VOICE_DOWNLINK, "VOICE_DOWNLINK", 8000))
         }
         return configs.filterNot { it.source in silentSourceIds }
@@ -616,6 +685,7 @@ class RtpSession(
         val record = audioRecord ?: return false
 
         record.startRecording()
+        Log.i(TAG, "Capture routedFrom=${record.routedDevice?.type}")
         Log.i(TAG, "Capture started: source=$audioSourceName capRate=$captureRate session=$audioSessionId gain=${captureGain}x profile=${profile.name} state=${record.recordingState}")
         // Also report via RTP stats so it appears in the app log viewer
         listener?.onRtpStats("Capture: source=$audioSourceName rate=$captureRate gain=${captureGain}x profile=${profile.name}")
@@ -686,7 +756,8 @@ class RtpSession(
                 }
 
                 val shouldForward: Boolean
-                if (decayingPlaybackRms > echoGateThreshold) {
+                if (profile.playbackLeaksIntoCapture &&
+                    decayingPlaybackRms > echoGateThreshold) {
                     // Agent is speaking (or echo tail still decaying) —
                     // check for double-talk (barge-in).
                     val expectedEcho = (echoGainRatio * decayingPlaybackRms).toInt()
@@ -881,6 +952,75 @@ class RtpSession(
 
     // ── Playback: jitter buffer → decode → speaker → mic → GSM uplink ──
 
+    /**
+     * Ask this recorder to take its audio from the telephony downlink.
+     *
+     * Logs the available input device types, since whether TYPE_TELEPHONY is
+     * offered at all is the thing worth knowing when the agent ends up hearing
+     * the room instead of the caller.
+     */
+    private fun routeCaptureToTelephonyRx(rec: AudioRecord) {
+        try {
+            val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+            val inputs = am.getDevices(AudioManager.GET_DEVICES_INPUTS)
+            Log.i(TAG, "Input devices: " + inputs.joinToString { "${it.type}/${it.productName}" })
+            val telephony = inputs.firstOrNull { it.type == AudioDeviceInfo.TYPE_TELEPHONY }
+            if (telephony == null) {
+                Log.w(TAG, "No TYPE_TELEPHONY input exposed — capture stays on the mic")
+                return
+            }
+            val accepted = rec.setPreferredDevice(telephony)
+            Log.i(TAG, "Capture preferred device -> TELEPHONY id=${telephony.id} accepted=$accepted")
+        } catch (e: Exception) {
+            Log.w(TAG, "routeCaptureToTelephonyRx failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Ask for this track to be routed to the telephony uplink.
+     *
+     * Logs every output device type it can see, because whether the platform
+     * exposes TYPE_TELEPHONY at all is the thing worth knowing when injection
+     * does not work.
+     */
+    private fun routeToTelephonyTx(track: AudioTrack) {
+        try {
+            val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+            val outputs = am.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            Log.i(TAG, "Output devices: " + outputs.joinToString { "${it.type}/${it.productName}" })
+            val telephony = outputs.firstOrNull { it.type == AudioDeviceInfo.TYPE_TELEPHONY }
+            if (telephony == null) {
+                Log.w(TAG, "No TYPE_TELEPHONY output exposed — cannot request the uplink route")
+                return
+            }
+            val accepted = track.setPreferredDevice(telephony)
+            Log.i(TAG, "Preferred device -> TELEPHONY id=${telephony.id} accepted=$accepted")
+        } catch (e: Exception) {
+            Log.w(TAG, "routeToTelephonyTx failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Duplicate each 16-bit mono sample into both channels.
+     *
+     * Needed only so the track can match the HAL's stereo-only
+     * incall_music_uplink mixPort; the content is still mono.
+     */
+    private fun monoToStereo(mono: ByteArray): ByteArray {
+        val out = ByteArray(mono.size * 2)
+        var i = 0
+        var j = 0
+        while (i + 1 < mono.size) {
+            val lo = mono[i]
+            val hi = mono[i + 1]
+            out[j] = lo; out[j + 1] = hi
+            out[j + 2] = lo; out[j + 3] = hi
+            i += 2
+            j += 4
+        }
+        return out
+    }
+
     private fun playbackLoop() {
         val track = audioTrack ?: return
 
@@ -888,7 +1028,8 @@ class RtpSession(
         // continuously, preventing underruns.  Removing the old 20ms prefill
         // saves that much initial latency.
         track.play()
-        Log.i(TAG, "Playback started (rate=$playbackRate usage=$playbackUsageName deepBuffer=true)")
+        Log.i(TAG, "Playback started (rate=$playbackRate usage=$playbackUsageName deepBuffer=true) " +
+            "routedTo=${track.routedDevice?.type}")
 
         // CRITICAL: Set incall_music_enabled=true AFTER AudioTrack.play().
         // The Qualcomm HAL starts the incall-music usecase only when there
@@ -904,7 +1045,7 @@ class RtpSession(
 
         // Silence frame for when jitter buffer is empty — prevents underruns
         // that cause BUFFER TIMEOUT and AudioTrack disable/restart cycles.
-        val silenceFrame = ByteArray(playbackRate * 2 / 50) // 20ms of silence
+        val silenceFrame = ByteArray(playbackRate * 2 * playbackChannels / 50) // 20ms
 
         // Track silence→speech transitions for fade-in.
         // Modem DSP AGC/DTX settles during silence; abrupt speech onset
@@ -974,7 +1115,8 @@ class RtpSession(
                 }
 
                 playbackRms = if (playbackGain > 1) pcmRms(pcm) else rawRms
-                track.write(pcm, 0, pcm.size)
+                val out = if (playbackChannels == 2) monoToStereo(pcm) else pcm
+                track.write(out, 0, out.size)
                 playbackFrames++
             } catch (e: InterruptedException) {
                 break

--- a/app/src/main/java/com/callagent/gateway/service/BootReceiver.kt
+++ b/app/src/main/java/com/callagent/gateway/service/BootReceiver.kt
@@ -38,14 +38,54 @@ class BootReceiver : BroadcastReceiver() {
             val user = prefs.getString("user", "") ?: ""
 
             if (server.isNotEmpty() && user.isNotEmpty()) {
-                Log.i(TAG, "Config found, starting gateway service")
+                Log.i(TAG, "Config found, starting gateway")
                 val port = prefs.getInt("port", 5060)
                 val pass = prefs.getString("pass", "") ?: ""
-                GatewayService.start(context, server, port, user, pass)
+                startViaActivity(context, server, port, user, pass)
             } else {
                 Log.i(TAG, "No config, skipping auto-start")
             }
         }
+    }
+
+    /**
+     * Bring the UI up first, and let it start the gateway service.
+     *
+     * Android 12+ withholds PROCESS_CAPABILITY_FOREGROUND_MICROPHONE from a
+     * foreground service that was started while the app was in the background
+     * — which is exactly what a BOOT_COMPLETED receiver is.  Nothing fails
+     * loudly: the service starts, AudioRecord starts, and AudioPolicy quietly
+     * feeds it zeros, so every capture source reads rawCapRMS=0 and the agent
+     * hears silence.  ("rec update ... silenced" in dumpsys audio.)
+     *
+     * Starting the Activity first means GatewayService is created while the
+     * app is TOP, which is the state that grants the capability; the service
+     * keeps it for its lifetime, so the UI can be dismissed afterwards.
+     *
+     * The launch goes through root because a background activity start from a
+     * receiver is itself refused on Android 15+ (BAL_BLOCK).  Without root we
+     * fall back to starting the service directly — the gateway will register
+     * and bridge, but capture will be silent until the app is opened by hand.
+     */
+    private fun startViaActivity(
+        context: Context, server: String, port: Int, user: String, pass: String
+    ) {
+        Thread({
+            val launched = try {
+                RootShell.exec(
+                    "am start -n ${context.packageName}/.MainActivity", timeoutMs = 10_000
+                ) == 0
+            } catch (e: Exception) {
+                Log.w(TAG, "Root activity launch failed: ${e.message}")
+                false
+            }
+            if (launched) {
+                Log.i(TAG, "MainActivity launched via root — it will start the service")
+            } else {
+                Log.w(TAG, "Could not launch UI; starting service directly (capture will be silenced)")
+                GatewayService.start(context, server, port, user, pass)
+            }
+        }, "boot-launch").start()
     }
 
     /**

--- a/app/src/main/java/com/callagent/gateway/service/GatewayService.kt
+++ b/app/src/main/java/com/callagent/gateway/service/GatewayService.kt
@@ -202,7 +202,14 @@ class GatewayService : Service() {
         // This prevents redundant ACTION_START intents (e.g. from the
         // Activity opening, START_STICKY restart, or BootReceiver) from
         // killing an active SIP registration or call bridge.
-        if (!stopped && sipClient != null) {
+        //
+        // `initializing` covers the window before sipClient is assigned:
+        // initSipClient() runs on the gateway-init thread, so two intents
+        // arriving back to back (START_STICKY redelivery with a null intent
+        // + the Activity's autoStartGateway) would both see a null sipClient
+        // and each bring up their own client — two sockets on :5060 and two
+        // REGISTERs.
+        if (!stopped && (sipClient != null || initializing.get())) {
             Log.i(TAG, "startGateway: already running, skipping restart")
             // Broadcast current state so the Activity picks up the live status
             val state = orchestrator?.bridgeState ?: CallOrchestrator.BridgeState.IDLE
@@ -233,7 +240,7 @@ class GatewayService : Service() {
         currentCallStart = 0L
 
         val prefs = getSharedPreferences("gateway", MODE_PRIVATE)
-        val server = intent?.getStringExtra(EXTRA_SERVER) ?: prefs.getString("server", "sip.callagent.pro") ?: ""
+        val server = intent?.getStringExtra(EXTRA_SERVER) ?: prefs.getString("server", "callagent.pro") ?: ""
         val port = intent?.getIntExtra(EXTRA_PORT, 5060) ?: prefs.getInt("port", 5060)
         val username = intent?.getStringExtra(EXTRA_USER) ?: prefs.getString("user", "") ?: ""
         val password = intent?.getStringExtra(EXTRA_PASS) ?: prefs.getString("pass", "") ?: ""

--- a/app/src/main/java/com/callagent/gateway/sip/SipClient.kt
+++ b/app/src/main/java/com/callagent/gateway/sip/SipClient.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
 
 /**
  * SIP client: handles UDP transport, registration, and call routing.
@@ -42,6 +43,13 @@ class SipClient(
     @Volatile private var lastServerResponseTime = 0L
     @Volatile private var registrationLatch: CountDownLatch? = null
 
+    /** Guards against two threads registering at once: start() launches a
+     *  SIP-Register thread while SIP-Monitor retries on its own schedule. */
+    private val registering = AtomicBoolean(false)
+
+    /** Consecutive real (not backed-off) registration failures. */
+    @Volatile private var registerFailures = 0
+
     private val activeCalls = ConcurrentHashMap<String, SipCall>()
     /** Single-thread executor for all socket sends — avoids NetworkOnMainThreadException */
     private var sendExecutor: ExecutorService? = null
@@ -69,6 +77,8 @@ class SipClient(
     fun start() {
         if (running.get()) return
         running.set(true)
+        SipBuilder.userAgent =
+            "gsm2sip v${com.callagent.gateway.BuildConfig.VERSION_NAME} $serverDomain"
         callIdBase = "${System.currentTimeMillis() / 1000}@$publicIp"
         createSocket()
 
@@ -253,27 +263,48 @@ class SipClient(
     // ── Registration ────────────────────────────────────
 
     /**
-     * Send REGISTER and wait for receiveLoop() to handle the response.
+     * Send ONE REGISTER and wait for receiveLoop() to handle the response.
      * Uses a CountDownLatch so only receiveLoop() reads from the socket
      * (eliminates the old race condition with waitForRegistration).
+     *
+     * Rate-limited by [RegisterBackoff]: while a previous failure's cooldown
+     * is still running this returns false without putting a packet on the
+     * wire.  Returns false immediately if another thread is already
+     * registering, so the startup and monitor threads cannot overlap.
      */
     private fun register(): Boolean {
-        for (attempt in 1..3) {
-            if (!running.get()) return false
-            uiLog("REGISTER attempt $attempt/3")
+        if (!running.get()) return false
+        if (!registering.compareAndSet(false, true)) {
+            Log.d(TAG, "REGISTER already in flight — skipping duplicate")
+            return false
+        }
+        try {
+            val hold = RegisterBackoff.holdOffMs(serverDomain)
+            if (hold > 0) {
+                Log.d(TAG, "REGISTER held off for ${hold / 1000}s more (backoff)")
+                return false
+            }
+            uiLog("REGISTER → $serverDomain")
             registrationLatch = CountDownLatch(1)
             sendRegister()
-            // Wait up to 10s for receiveLoop → handleRegisterResponse to signal
+            // Wait for receiveLoop → handleRegisterResponse to signal
             try {
-                registrationLatch?.await(10, TimeUnit.SECONDS)
-            } catch (_: InterruptedException) { /* stop requested */ }
-            if (registered) return true
+                registrationLatch?.await(REGISTER_TIMEOUT_SEC, TimeUnit.SECONDS)
+            } catch (_: InterruptedException) { return false }
+            if (registered) {
+                RegisterBackoff.onSuccess()
+                registerFailures = 0
+                return true
+            }
             if (!running.get()) return false
-            Thread.sleep(2000)
+            val next = RegisterBackoff.onFailure()
+            registerFailures++
+            uiLog("REGISTER failed — next attempt in ${next / 1000}s")
+            listener?.onRegistrationFailed()
+            return false
+        } finally {
+            registering.set(false)
         }
-        uiLog("Registration failed after 3 attempts")
-        listener?.onRegistrationFailed()
-        return false
     }
 
     private fun sendRegister(auth: String? = null) {
@@ -384,7 +415,9 @@ class SipClient(
 
         activeCalls[callId] = call
         sendTo(invite, serverAddress)
-        Log.i(TAG, "Sent INVITE to $targetExtension (call-id=$callId)")
+        // Log both halves the server routes on: the Request-URI it turns into
+        // EXTEN, and the From user it turns into caller ID.
+        Log.i(TAG, "Sent INVITE RURI=$targetUri From=<sip:$fromUser@$serverDomain> (call-id=$callId)")
 
         // RFC 3261 Timer A: retransmit INVITE over UDP until any response is received.
         // Intervals: 500ms, 1s, 2s, 4s (capped at T2=4s). Stops immediately when
@@ -443,25 +476,22 @@ class SipClient(
 
     private fun monitorLoop() {
         Thread.sleep(15_000)
-        var reregBackoff = 10_000L // start at 10s, backoff on repeated failures
         while (running.get()) {
             try {
                 if (!registered) {
-                    uiLog("Not registered, attempting re-registration (backoff ${reregBackoff / 1000}s)")
-                    val ok = register()
-                    if (ok) {
-                        reregBackoff = 10_000L
+                    // register() rate-limits itself — while the cooldown is
+                    // running it returns without sending anything, so polling
+                    // once per loop costs no traffic.
+                    if (register()) {
                         keepaliveFailures = 0
-                    } else {
-                        // Exponential backoff: 10s, 20s, 40s, cap at 60s
-                        Thread.sleep(reregBackoff)
-                        reregBackoff = (reregBackoff * 2).coerceAtMost(60_000L)
-                        // After repeated failures, signal that we need a full reconnect
-                        if (reregBackoff >= 60_000L) {
-                            uiLog("Registration failed repeatedly, requesting reconnect")
-                            onConnectionLost?.invoke()
-                        }
-                        continue
+                    } else if (registerFailures >= MAX_REGISTER_FAILURES) {
+                        // Rebuild the socket in case the local IP changed.
+                        // Safe to repeat: the backoff schedule lives in the
+                        // companion, so the replacement SipClient inherits the
+                        // cooldown instead of restarting the retry cycle.
+                        uiLog("Registration failing repeatedly, requesting reconnect")
+                        registerFailures = 0
+                        onConnectionLost?.invoke()
                     }
                 } else {
                     // Send OPTIONS keepalive regardless of active calls
@@ -501,6 +531,7 @@ class SipClient(
             append("OPTIONS sip:$serverDomain:$serverPort SIP/2.0\r\n")
             append("Via: SIP/2.0/UDP $publicIp:$localPort;branch=$branch;rport\r\n")
             append("Max-Forwards: 70\r\n")
+            append("User-Agent: ${SipBuilder.userAgent}\r\n")
             append("To: <sip:$username@$serverDomain>\r\n")
             append("From: <sip:$username@$publicIp>;tag=49583\r\n")
             append("Call-ID: $callIdBase\r\n")
@@ -513,5 +544,58 @@ class SipClient(
 
     companion object {
         private const val TAG = "SipClient"
+
+        /** Seconds to wait for a REGISTER response before calling it failed. */
+        private const val REGISTER_TIMEOUT_SEC = 10L
+
+        /** Consecutive failures before asking GatewayService for a new socket. */
+        private const val MAX_REGISTER_FAILURES = 3
+
+        /**
+         * Exponential backoff for REGISTER, shared by every SipClient.
+         *
+         * It lives in the companion rather than on the instance because a run
+         * of failures ends in onConnectionLost() → GatewayService.reconnect(),
+         * which discards the SipClient and builds a new one.  With per-instance
+         * state the replacement restarted at the shortest delay, so an
+         * unreachable server produced a steady REGISTER flood — three packets
+         * per attempt, a fresh attempt every ~10s, a full reconnect every ~2
+         * minutes — until the server's fail2ban banned the gateway's IP.
+         * Keeping the schedule here means a new client picks the cooldown up
+         * where the old one left off.
+         */
+        private object RegisterBackoff {
+            private const val MIN_MS = 15_000L
+            private const val MAX_MS = 30 * 60 * 1000L
+
+            private var target = ""
+            private var delayMs = MIN_MS
+            private var nextAttemptAt = 0L
+
+            /** Millis still to wait before a REGISTER may be sent (0 = now). */
+            @Synchronized fun holdOffMs(server: String): Long {
+                if (server != target) {
+                    // Different server (or first use) — start clean.
+                    target = server
+                    delayMs = MIN_MS
+                    nextAttemptAt = 0L
+                }
+                return (nextAttemptAt - System.currentTimeMillis()).coerceAtLeast(0L)
+            }
+
+            @Synchronized fun onSuccess() {
+                delayMs = MIN_MS
+                nextAttemptAt = 0L
+            }
+
+            /** Doubles the delay (capped) and returns the wait just applied.
+             *  Jittered so several gateways on one server don't retry in step. */
+            @Synchronized fun onFailure(): Long {
+                val wait = (delayMs * (0.8 + Random.nextDouble() * 0.4)).toLong()
+                nextAttemptAt = System.currentTimeMillis() + wait
+                delayMs = (delayMs * 2).coerceAtMost(MAX_MS)
+                return wait
+            }
+        }
     }
 }

--- a/app/src/main/java/com/callagent/gateway/sip/SipMessage.kt
+++ b/app/src/main/java/com/callagent/gateway/sip/SipMessage.kt
@@ -199,6 +199,15 @@ class SipMessage private constructor(
 
 /** Builder for constructing SIP messages */
 object SipBuilder {
+    /**
+     * How this gateway identifies itself in SIP traffic, the way a Fritz!Box
+     * announces itself as "AVM FRITZ!Box 7530 AX".  Without it the device is
+     * anonymous in the server's logs and CDRs.  SipClient sets it once at
+     * startup so the configured server domain can be included.
+     */
+    @Volatile
+    var userAgent: String = "gsm2sip"
+
     private fun branch(): String = "z9hG4bK${(100000000..999999999).random()}"
     private fun tag(): String = "gw${(100000000..999999999).random()}"
 
@@ -213,6 +222,7 @@ object SipBuilder {
             append("REGISTER $uri SIP/2.0\r\n")
             append("Via: SIP/2.0/UDP $localIp:$localPort;branch=${branch()};rport\r\n")
             append("Max-Forwards: 70\r\n")
+            append("User-Agent: $userAgent\r\n")
             append("To: <sip:$username@$domain>\r\n")
             append("From: <sip:$username@$localIp>;tag=${tag()}\r\n")
             append("Call-ID: $callId\r\n")
@@ -241,6 +251,7 @@ object SipBuilder {
             append("INVITE $targetUri SIP/2.0\r\n")
             append("Via: SIP/2.0/UDP $localIp:$localPort;branch=${branch()};rport\r\n")
             append("Max-Forwards: 70\r\n")
+            append("User-Agent: $userAgent\r\n")
             append("To: <$targetUri>\r\n")
             append("From: $fromDisplay<sip:$fromUser@$domain>;tag=$fromTag\r\n")
             append("Call-ID: $callId\r\n")
@@ -287,6 +298,7 @@ object SipBuilder {
         append("From: ${msg.from}\r\n")
         append("Call-ID: ${msg.callId}\r\n")
         append("CSeq: ${msg.cseq}\r\n")
+        append("Server: $userAgent\r\n")
         append("Content-Length: 0\r\n\r\n")
     }
 
@@ -300,6 +312,7 @@ object SipBuilder {
             append("From: ${msg.from}\r\n")
             append("Call-ID: ${msg.callId}\r\n")
             append("CSeq: ${msg.cseq}\r\n")
+            append("Server: $userAgent\r\n")
             append("Content-Length: 0\r\n\r\n")
         }
     }
@@ -313,6 +326,7 @@ object SipBuilder {
         append("ACK $targetUri SIP/2.0\r\n")
         append("Via: SIP/2.0/UDP $localIp:$localPort;branch=${branch()};rport\r\n")
         append("Max-Forwards: 70\r\n")
+            append("User-Agent: $userAgent\r\n")
         append("To: $toHeader\r\n")
         append("From: $fromHeader\r\n")
         append("Call-ID: $callId\r\n")
@@ -330,6 +344,7 @@ object SipBuilder {
         append("BYE $targetUri SIP/2.0\r\n")
         append("Via: SIP/2.0/UDP $localIp:$localPort;branch=${branch()};rport\r\n")
         append("Max-Forwards: 70\r\n")
+            append("User-Agent: $userAgent\r\n")
         append("From: $fromHeader\r\n")
         append("To: $toHeader\r\n")
         append("Call-ID: $callId\r\n")
@@ -347,6 +362,7 @@ object SipBuilder {
         append("CANCEL $targetUri SIP/2.0\r\n")
         append("Via: $viaHeader\r\n")
         append("Max-Forwards: 70\r\n")
+            append("User-Agent: $userAgent\r\n")
         append("From: $fromHeader\r\n")
         append("To: $toHeader\r\n")
         append("Call-ID: $callId\r\n")

--- a/app/src/main/res/layout/dialog_config.xml
+++ b/app/src/main/res/layout/dialog_config.xml
@@ -92,6 +92,31 @@
         android:inputType="textPassword"
         android:importantForAutofill="no" />
 
+    <!-- Own number: the MSISDN of the SIM in this phone.  Sent as the SIP
+         destination so the server can map the call to an assistant, the same
+         way a Fritz!Box sends the DID that was dialled.  Use the format the
+         server's number table stores (e.g. 015215320372). -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Own Number (SIM)"
+        android:textStyle="bold"
+        android:textColor="@color/text_label"
+        android:layout_marginTop="12dp" />
+
+    <EditText
+        android:id="@+id/etOwnNumber"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="international, e.g. +4915215320372"
+        android:textColor="@color/text_primary"
+        android:textColorHint="@color/text_hint"
+        android:background="@drawable/input_bg"
+        android:padding="10dp"
+        android:layout_marginTop="4dp"
+        android:inputType="phone"
+        android:importantForAutofill="no" />
+
     <!-- Autoconnect -->
     <CheckBox
         android:id="@+id/cbAutoconnect"


### PR DESCRIPTION
Adds an sm6150 device profile and fixes the platform-level problems that kept the bridge from working at all on Android 16.  Verified end to end on a Poco X3 NFC (SM7150, WCD9375, LineageOS 23) against callagent.pro: the caller hears the agent clearly, and the agent hears the caller.

Android 16 blockers

  Outbound GSM never dialled.  GsmCallManager used
  startActivity(ACTION_CALL) from a foreground service; Android 15+ refuses
  background activity launches (BAL_BLOCK), so a headless gateway — the
  whole point of the app — could not place calls.  Uses
  TelecomManager.placeCall, keeping the intent as a fallback.

  Capture returned pure silence.  A foreground service started from
  BootReceiver never receives PROCESS_CAPABILITY_FOREGROUND_MICROPHONE, so
  AudioPolicy silently fed AudioRecord zeros ("rec update ... silenced" in
  dumpsys audio) and every source read rawCapRMS=0.  Nothing errors.  Boot
  now launches the Activity via root and lets it start the service, which
  is created while the app is TOP and keeps the capability afterwards.
  Note the module's PermissionController overlay is a no-op here — on
  Android 16 it lives in an APEX that Magisk cannot shadow.

  MMI/USSD codes killed telephony.  Dialling *132# went to Telecom as a
  call, which returned DIALED_MMI and took TelephonyConnectionService down
  with it.  Codes are now detected before the bridge is armed and sent via
  sendUssdRequest, with the network's reply logged.

SIP

  The gateway INVITEd its own extension, so the server matched it as a
  local peer and rang us back; the orchestrator rejected its own call as
  busy and the GSM leg was never answered.  The dialled MSISDN is now
  configurable ("Own Number"), asked of the platform first and normalised
  to E.164 via PhoneNumberUtils.  From already carried the real caller.

  REGISTER flooded the server into banning us.  register() ran from two
  threads at once, sent three packets per attempt, and — the reason a ban
  was inevitable — a failure ended in reconnect(), which rebuilt SipClient
  and reset the backoff every couple of minutes.  One packet per attempt
  now, a CAS guard, and the schedule lives in the companion so it survives
  client rebuilds: 15s doubling to 30min, jittered.  Measured 3 REGISTERs
  across a full ban-and-recover cycle.

  Also: a START_STICKY redelivery raced the Activity's autostart because
  the guard tested sipClient, which is assigned later on a worker thread —
  two clients bound :5060 and registered separately.  And SIP messages now
  carry a User-Agent.

Audio on SM6150

  Four independent things had to be right before injected audio reached the
  modem uplink, each found from device evidence:

    Incall_Music must be open on the port the track actually uses.  The
    track lands on MultiMedia5 here, not MultiMedia1/2 as on MSM8930.

    The track must not take AudioFlinger's fast path.  RtpSession asked for
    minPlayBuf, which the HAL serves as low-latency-playback on MultiMedia5
    — a front-end wired to the speaker.  Now profile-driven (100ms).

    The track must be stereo.  audio_policy_configuration.xml declares the
    incall_music_uplink mixPort — the only one routed to Telephony Tx — as
    AUDIO_CHANNEL_OUT_STEREO, so a mono track can never be matched to it.

    incall_music_enabled must be set before the track is created, and the
    track must name the telephony device as its preferred device.  The
    parameter alone leaves it on the speaker.

  Capture is acoustic and stays that way.  Every digital route this build
  offers was tested and returns silence: VOICE_CALL, VOICE_DOWNLINK,
  VOC_REC_DL/UL with Voc Rec Config, and telephony-RX via
  setPreferredDevice (accepted, routedFrom=18, still zeros).  The HAL
  advertises incall-rec-uplink-and-downlink in mixer_paths.xml but does not
  deliver it; stock MIUI likely would.  So the profile drives the downlink
  loud, captures with UNPROCESSED to bypass the AEC/NS/AGC chain built to
  remove exactly that speaker signal, and disables the double-talk gate,
  which had nothing to gate once playback stopped reaching the speaker.

  The voice mute controls are 3-element arrays written as
  {mute, session_vsid, ramp_ms}; single-value writes set only element 0 and
  silently do nothing.

Cleanups

  mixerDiagGrep was declared on all five profiles and never read; it is now
  mixerVerifyCmd, a per-profile readback logged around mixer setup, which
  also moves the hardcoded ABOX NSRC strings out of the shared call path
  into the Exynos profile where they apply.  voiceDownlinkWorks now
  actually orders the capture sources instead of being ignored.


Claude-Session: https://claude.ai/code/session_016NC162vqC9nFLHE2WwzRDU